### PR TITLE
feat: add support php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "8.5.*",
+        "php": "^8.2",
         "illuminate/database": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "8.5.*",
         "illuminate/database": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"
     },


### PR DESCRIPTION
This pull request updates the project's PHP version support to target only PHP 8.5, removing compatibility with earlier 8.x versions. This change affects both the Composer configuration and the GitHub Actions test matrix, ensuring that all dependencies and CI tests are aligned with this new minimum PHP requirement.

**Dependency and CI configuration updates:**

* Updated the required PHP version in `composer.json` to only allow `8.5.*`, dropping support for PHP 8.2, 8.3, and 8.4.
* Modified the GitHub Actions workflow (`.github/workflows/tests.yml`) to run tests exclusively on PHP 8.5, removing earlier versions from the test matrix.

Ref: #57416

