### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^1.0",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the project's dependencies and test workflow to add support for Laravel 13 and PHPUnit 12, ensuring compatibility with the latest versions of these frameworks. It also improves the test matrix to provide more granular control over which combinations of PHP, Laravel, and PHPUnit are tested.

**Dependency and compatibility updates:**

* Added support for Laravel 13 and PHPUnit 12 in both `require` and `require-dev` sections of `composer.json`, allowing the package to be installed and tested with these new versions.

**CI workflow improvements:**

* Expanded the GitHub Actions test matrix to include Laravel 13, PHPUnit 12, and Testbench 11, and added exclusions to prevent unsupported version combinations.
* Updated the dependencies installation step in the workflow to require the appropriate PHPUnit version for each matrix entry.
* Added `workflow_dispatch` to the workflow triggers, allowing manual runs of the test workflow.
* Improved the job naming in the workflow to include the PHPUnit version for better clarity in CI results.