### PR TITLE
feat: drop support for PHP 8.2 and Laravel 11, update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,6 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 11.*
-            phpunit: 12.*
           - laravel: 12.*
             phpunit: 12.*
           - laravel: 13.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*, 13.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*
@@ -27,8 +25,6 @@ jobs:
             phpunit: 12.*
           - laravel: 13.*
             phpunit: 11.*
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/database": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "php": "^8.3",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^1.0",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },


### PR DESCRIPTION
This pull request updates the package to require newer versions of PHP and Laravel, and removes support for older versions in both the code and the test matrix. The changes ensure compatibility with only the latest supported versions and simplify the testing configuration.

Dependency and compatibility updates:

* Updated `composer.json` to require PHP 8.3 or higher, and only support `illuminate/database` and `illuminate/support` versions 12.x and 13.x. Dropped support for older versions.
* Updated `composer.json` to require `orchestra/testbench` 10.x or 11.x only, removing support for 9.x.

Testing matrix simplification:

* Updated `.github/workflows/tests.yml` to remove PHP 8.2 and Laravel 11.x from the test matrix, testing only against PHP 8.3+, Laravel 12.x/13.x, and the appropriate PHPUnit/Testbench versions. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-L18) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL30-L31)

Ref: #59909